### PR TITLE
fix: Run under coc.nvim

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ EShLanguage find_language(const std::string& name)
         return EShLangFragment;
     else if (ext == ".comp")
         return EShLangCompute;
-	throw std::invalid_argument("Unknown file extension!");
+    throw std::invalid_argument("Unknown file extension!");
 }
 
 json get_diagnostics(std::string uri, std::string content,

--- a/src/messagebuffer.cpp
+++ b/src/messagebuffer.cpp
@@ -1,5 +1,4 @@
 #include "messagebuffer.hpp"
-#include <iostream>
 
 MessageBuffer::MessageBuffer() {}
 MessageBuffer::~MessageBuffer() {}
@@ -60,7 +59,7 @@ void MessageBuffer::handle_string(std::string s)
         // we reach the length of the body as provided in the Content-Length
         // header.
         auto content_length = std::stoi(m_headers["Content-Length"]);
-        if (m_raw_message.length() >= content_length) {
+        if (m_raw_message.length() == content_length) {
             m_body = json::parse(m_raw_message);
         }
     }

--- a/src/messagebuffer.cpp
+++ b/src/messagebuffer.cpp
@@ -1,4 +1,5 @@
 #include "messagebuffer.hpp"
+#include <iostream>
 
 MessageBuffer::MessageBuffer() {}
 MessageBuffer::~MessageBuffer() {}
@@ -59,7 +60,7 @@ void MessageBuffer::handle_string(std::string s)
         // we reach the length of the body as provided in the Content-Length
         // header.
         auto content_length = std::stoi(m_headers["Content-Length"]);
-        if (m_raw_message.length() == content_length) {
+        if (m_raw_message.length() >= content_length) {
             m_body = json::parse(m_raw_message);
         }
     }


### PR DESCRIPTION
Hello,

I've recently started experimenting with this tool and https://github.com/neoclide/coc.nvim. I've noticed a few things:

1- The tool doesn't handle initialize method, so it crashes quickly.
2- glslang's diagnostics appear to print output to stdout as well as the message buffer. This causes the client to struggle with parsing when the input file is invalid.

With theses hacky patches in place I  got it to a mostly working state:
![image](https://user-images.githubusercontent.com/249390/64929243-b5e0a780-d7f1-11e9-8487-aa4de55087d9.png)

I'm not a regular C++ developer so admittedly I am not sure on the best style or approach. I'm not sure how paranoid I should be about exceptions being thrown and things like that where I might lose `fp_old` nor how I would do the same redirect in c++ directly.

I'd like to also see if newer versions of glslang behave a little better so I'll also explore upgrading that module.