### PR TITLE
Link the language server against SPIRV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(glslls
     nlohmann_json
     mongoose
     stdc++fs
+    SPIRV
     fmt::fmt-header-only
 )
 


### PR DESCRIPTION
On Darwin the linker doens't keep around a few symbols from libSPIRV
while linking against glslang and thus the link fails. Explicitly add
the SPIRV dependency here.