### PR TITLE
Update glslang.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,7 +73,7 @@ json get_diagnostics(std::string uri, std::string content,
     glslang::InitializeProcess();
     glslang::TShader shader(lang);
     shader.setStrings(&shader_cstring, 1);
-    TBuiltInResource Resources = glslang::DefaultTBuiltInResource;
+    TBuiltInResource Resources = *GetDefaultResources();
     EShMessages messages = EShMsgCascadingErrors;
     shader.parse(&Resources, 110, false, messages);
     std::string debug_log = shader.getInfoLog();


### PR DESCRIPTION
A very small PR - I don't know how much of a difference this actually makes, but I saw that the glslang submodule was on a commit about 2 years old, so I updated it. The only change to the source is just an API change of calling `GetDefaultResources()` like is shown in this [example](https://github.com/KhronosGroup/glslang/blob/5e08deae050c4a6d5b2ca92cb6cc52ccc5259bea/StandAlone/StandAlone.cpp#L160).