### PR TITLE
Update README with an example for usage in Emacs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,20 @@ You can also use the `Makefile` in the project root which is provided for conven
 
 You can run `glslls` to use a HTTP server to handle IO. Alternatively, run
 `glslls --stdin` to handle IO on stdin.
+
+## Editor Examples
+The following are examples of how to run `glslls` from various editors that support LSP.
+
+### Emacs
+Add the following to your `init.el`, or other config file.
+This assumes you have [glsl-mode](https://github.com/jimhourihan/glsl-mode) installed.
+See the [lsp-mode docs](https://emacs-lsp.github.io/lsp-mode/page/adding-new-language/) for more details.
+```elisp
+(with-eval-after-load 'lsp-mode
+  (add-to-list 'lsp-language-id-configuration
+               '(glsl-mode . "glsl"))
+  (lsp-register-client
+   (make-lsp-client :new-connection (lsp-stdio-connection '("glslls" "--stdin"))
+                    :activation-fn (lsp-activate-on "glsl")
+                    :server-id 'glslls)))
+```


### PR DESCRIPTION
This also gives a section to add configuration examples for other editor such as neovim. I understand if this is not something you feel is in the scope of this project's README, I just think it's something that would make using `glslls` a little easier.

Thanks for the great project!