### PR TITLE
Added support for .glsl file extension

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,8 @@ std::string make_response(const json& response)
 EShLanguage find_language(const std::string& name)
 {
     auto ext = fs::path(name).extension();
+    if (ext == ".glsl")
+        ext = fs::path(name).replace_extension().extension(); //replaces current extension with nothing and finds new file extension
     if (ext == ".vert" || ext == ".vs")
         return EShLangVertex;
     else if (ext == ".tesc")


### PR DESCRIPTION
I figured it would be a good option to include the .glsl file extension as an option since some vulkan implementations use the extension format of .vert.glsl or .vert.hlsl in their shaders. It is also appears to be the default option in neovim using lsp-zero's lspconfig and treesitter to detect glsl files.