### PR TITLE
Fix json reponse data types

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -338,23 +338,23 @@ std::optional<std::string> handle_message(const MessageBuffer& message_buffer, A
 
         json completion_provider{
             { "resolveProvider", false },
-            { "triggerCharacters", {} },
+            { "triggerCharacters", json::array() },
         };
         json signature_help_provider{
-            { "triggerCharacters", "" }
+            { "triggerCharacters", json::array() }
         };
         json code_lens_provider{
             { "resolveProvider", false }
         };
         json document_on_type_formatting_provider{
             { "firstTriggerCharacter", "" },
-            { "moreTriggerCharacter", "" },
+            { "moreTriggerCharacter", json::array() },
         };
         json document_link_provider{
             { "resolveProvider", false }
         };
         json execute_command_provider{
-            { "commands", {} }
+            { "commands", json::array() }
         };
         json result{
             {


### PR DESCRIPTION
Some text editors like Helix are more strict with the json response data types. This commit updates these values:

- triggerCharacters for `completion_provider`, `signature_help_provider`
- moreTriggerCharacter for `document_on_type_formatting_provider`
- commands for `execute_command_provider`

Based on: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#signatureHelpOptions

fixes #35