### PR TITLE
Optional http

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(glsl-language-server)
 find_package(Threads REQUIRED)
 
 option(USE_SYSTEM_LIBS "Use system libraries" OFF)
+option(HTTP_SUPPORT "Enable HTTP support" ON)
+
+if (HTTP_SUPPORT)
+    add_definitions(-DHAVE_HTTP_SUPPORT)
+endif()
 
 if (USE_SYSTEM_LIBS)
     find_package(glslang REQUIRED)
@@ -12,12 +17,14 @@ if (USE_SYSTEM_LIBS)
     find_package(fmt REQUIRED)
     message(STATUS "found package fmt, version: ${fmt_VERSION}")
 
-    find_library(mongoose mongoose)
+    if (HTTP_SUPPORT)
+        find_library(mongoose mongoose)
 
-    if (mongoose)
-        message(STATUS "found library mongoose located in: ${mongoose}")
-    else()
-        message(FATAL_ERROR "mongoose library not found")
+        if (mongoose)
+            message(STATUS "found library mongoose located in: ${mongoose}")
+        else()
+            message(FATAL_ERROR "mongoose library not found")
+        endif()
     endif()
 else()
     add_subdirectory(externals/glslang EXCLUDE_FROM_ALL)
@@ -73,8 +80,11 @@ if (USE_SYSTEM_LIBS)
     target_link_libraries(glslls
         glslang::glslang
         glslang::glslang-default-resource-limits
-        ${mongoose}
     )
+
+    if (HTTP_SUPPORT)
+        target_link_libraries(glslls ${mongoose})
+    endif()
 else()
     target_sources(glslls PRIVATE externals/glslang/StandAlone/ResourceLimits.cpp)
     target_link_libraries(glslls

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,9 @@
 
 #include <nlohmann/json.hpp>
 
+#ifdef HAVE_HTTP_SUPPORT
 #include <mongoose.h>
+#endif
 
 #include <glslang/Public/ResourceLimits.h>
 #include <glslang/Public/ShaderLang.h>
@@ -510,6 +512,7 @@ std::optional<std::string> handle_message(const MessageBuffer& message_buffer, A
     return make_response(result_body);
 }
 
+#ifdef HAVE_HTTP_SUPPORT
 void ev_handler(struct mg_connection* c, int ev, void* p) {
     AppState& appstate = *static_cast<AppState*>(c->mgr->user_data);
 
@@ -550,6 +553,7 @@ void ev_handler(struct mg_connection* c, int ev, void* p) {
         }
     }
 }
+#endif
 
 int main(int argc, char* argv[])
 {
@@ -667,6 +671,7 @@ int main(int argc, char* argv[])
         auto diagnostics = get_diagnostics(uri, contents, appstate);
         fmt::print("diagnostics: {}\n", diagnostics.dump(4));
     } else if (!use_stdin) {
+#ifdef HAVE_HTTP_SUPPORT
         struct mg_mgr mgr;
         struct mg_connection* nc;
         struct mg_bind_opts bind_opts;
@@ -687,6 +692,10 @@ int main(int argc, char* argv[])
             mg_mgr_poll(&mgr, 1000);
         }
         mg_mgr_free(&mgr);
+#else
+        fmt::print("This version of glslls was built without support for HTTP communication\n");
+        return 1;
+#endif
     } else {
         char c;
         MessageBuffer message_buffer;


### PR DESCRIPTION
In addition to https://github.com/svenstaro/glsl-language-server/pull/43, this change conditionalizes the use of mongoose library. I was trying really hard to find a Linux distro that provides mongoose 6.9 but none of Fedora, Debian or Arch provide it.
Therefore I assume it is good to make it simple to disable HTTP support.