### PR TITLE
feat: Compile on Clang 18.0.0 and MSVC 19.37.32822.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,21 +58,12 @@ add_executable(glslls
     ${SOURCES}
 )
 
-if (MSVC)
-    target_compile_options(glslls PRIVATE /W4)
-else()
-    target_compile_options(glslls PRIVATE -Wall -Wextra -Wpedantic)
-endif()
-
-if (CMAKE_SYSTEM_NAME MATCHES Darwin OR CMAKE_SYSTEM_NAME MATCHES FreeBSD)
-    set(stdfs)
-else()
-    set(stdfs stdc++fs)
-endif()
-
 target_link_libraries(glslls
     ${CMAKE_THREAD_LIBS_INIT}
-    ${stdfs}
+    glslang
+    nlohmann_json
+    mongoose
+    SPIRV
     fmt::fmt-header-only
 )
 

--- a/src/includer.cpp
+++ b/src/includer.cpp
@@ -24,14 +24,14 @@ IncludeResult* FileIncluder::includeLocal(
     path = fs::absolute(path);
 
     std::string uri = "file://";
-    uri += path;
+    uri += path.string();
 
     auto& documents = this->workspace->documents();
 
     auto existing = documents.find(uri);
     if (existing == documents.end()) {
         // load the file
-        if (auto contents = read_file_to_string(path.c_str())) {
+        if (auto contents = read_file_to_string(path.string().c_str())) {
             documents[uri] = *contents;
             existing = documents.find(uri);
         } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,18 +70,21 @@ EShLanguage find_language(const std::string& name)
     // This function attempts to support the most common ones, by checking if the filename ends with one of a list of known extensions.
     // If a ".glsl" extension is found initially, it is first removed to allow for e.g. vs.glsl/vert.glsl naming.
     auto path = fs::path(name);
-    auto ext = std::string(path.extension());
-    if (ext == ".glsl")
-        ext = path.replace_extension();
+    auto ext_path = path.extension();
+    if (ext_path == ".glsl")
+        ext_path = path.replace_extension();
+
+    const auto ext = ext_path.string();
+
     if (ext.ends_with("vert") || ext.ends_with("vs") || ext.ends_with("vsh"))
         return EShLangVertex;
     else if (ext.ends_with("tesc"))
         return EShLangTessControl;
     else if (ext.ends_with("tese"))
         return EShLangTessEvaluation;
-	 else if (ext.ends_with("geom") || ext.ends_with("gs") || ext.ends_with("gsh"))
+    else if (ext.ends_with("geom") || ext.ends_with("gs") || ext.ends_with("gsh"))
         return EShLangGeometry;
-	 else if (ext.ends_with("frag") || ext.ends_with("fs") || ext.ends_with("fsh"))
+    else if (ext.ends_with("frag") || ext.ends_with("fs") || ext.ends_with("fsh"))
         return EShLangFragment;
     else if (ext.ends_with("comp"))
         return EShLangCompute;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -108,18 +108,16 @@ int get_word_end(const char* text, int start) {
 }
 
 std::optional<std::string> read_file_to_string(const char* path) {
-    std::ifstream input_stream {path, std::fstream::in | std::fstream::ate};
+    std::ifstream input_stream {path, std::fstream::in};
     if (!input_stream) return std::nullopt;
 
-    const std::size_t size = input_stream.tellg();
+    const std::size_t size = fs::file_size(path);
     std::string buffer(size, '\0');
 
-    input_stream.seekg(0);
     input_stream.read(buffer.data(), size);
 
     return buffer;
 }
-
 
 std::string make_path_uri(const std::string& path) {
     return "file://" + fs::absolute(path).string();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,6 +3,7 @@
 #include <regex>
 #include <cstdio>
 #include <filesystem>
+#include <fstream>
 
 namespace fs = std::filesystem;
 
@@ -107,25 +108,21 @@ int get_word_end(const char* text, int start) {
 }
 
 std::optional<std::string> read_file_to_string(const char* path) {
-    FILE* f = fopen(path, "r");
-    if (!f) return std::nullopt;
+    std::ifstream input_stream {path, std::fstream::in | std::fstream::ate};
+    if (!input_stream) return std::nullopt;
 
-    fseek(f, 0, SEEK_END);
-    size_t size = ftell(f);
+    const std::size_t size = input_stream.tellg();
+    std::string buffer(size, '\0');
 
-    std::string contents;
-    contents.resize(size);
+    input_stream.seekg(0);
+    input_stream.read(buffer.data(), size);
 
-    rewind(f);
-    size_t actual = fread(&contents[0], sizeof(char), size, f);
-    contents.resize(actual);
-
-    return contents;
+    return buffer;
 }
 
 
 std::string make_path_uri(const std::string& path) {
-    return "file://" + std::string(fs::absolute(path));
+    return "file://" + fs::absolute(path).string();
 }
 
 const char* strip_prefix(const char* prefix, const char* haystack) {


### PR DESCRIPTION
This simple patch allows for compiling on latest gen compilers. We remove stdc++fs and improve std::filesystem::path -> std::string conversion. Also use std::ifstream over FILE 😊