### PR TITLE
do not include non-public header

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,6 @@
 
 #include <glslang/Public/ResourceLimits.h>
 #include <glslang/Public/ShaderLang.h>
-#include <glslang/MachineIndependent/Initialize.h>
 
 #include <cstdint>
 #include <filesystem>


### PR DESCRIPTION
`glslang/MachineIndependent/Initialize.h` is not redistributed anymore by glslang project when installing. so we cannot rely on it.

see also https://github.com/KhronosGroup/glslang/commit/1dcb072cda091180a5b8b03c030bcbe83a54f8e2