### PR TITLE
Small Bugfixes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,7 +166,15 @@ json get_diagnostics(std::string uri, std::string content,
 
             // -1 because lines are 0-indexed as per LSP specification.
             int line_no = std::stoi(matches[3]) - 1;
-            std::string source_line = content_lines[line_no];
+            std::string source_line;
+            //file might end with '\n' then line_no can be out of range in some cases
+            if(line_no<content_lines.size()){
+                source_line = content_lines[line_no];
+            }
+            else{
+                source_line = "";
+            }
+    
 
             int start_char = -1;
             int end_char = -1;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -110,6 +110,8 @@ int get_word_end(const char* text, int start) {
 std::optional<std::string> read_file_to_string(const char* path) {
     std::ifstream input_stream {path, std::fstream::in};
     if (!input_stream) return std::nullopt;
+    if(!fs::is_regular_file(path)) return std::nullopt;
+    
 
     const std::size_t size = fs::file_size(path);
     std::string buffer(size, '\0');


### PR DESCRIPTION
While using the LSP I encountered some segfaults/exceptions.
This fixes two of them:
1.  When typing includes the LSP sometimes tries to stat a directory, which causes an exception
2.  Trailing \n can cause buffer overflow 